### PR TITLE
Upload parallelism and retries

### DIFF
--- a/Tree Tracker/Screens/Upload/UploadViewModel.swift
+++ b/Tree Tracker/Screens/Upload/UploadViewModel.swift
@@ -159,12 +159,18 @@ final class UploadViewModel: CollectionViewModel {
                             self?.database.save([airtableTree], sentFromThisDevice: true)
                             self?.database.remove(tree: tree) {
                                 self?.currentUploads[tree.phImageId] = nil;
+                                if (self != nil && self!.currentUploads.count == 0) {
+                                    self?.presentUploadButton(isUploading: false)
+                                }
                                 self?.presentTreesFromDatabase()
                                 self?.uploadLocalTreesRecursively()
                             }
                         case let .failure(error):
+                            self?.currentUploads[tree.phImageId] = nil;
+                            if (self != nil && self!.currentUploads.count == 0) {
+                                self?.presentUploadButton(isUploading: false)
+                            }
                             self?.update(uploadProgress: 0.0, for: tree)
-                            self?.presentUploadButton(isUploading: false)
                             self?.logger.log(.upload, "Error when uploading a local tree: \(error)")
                         }
                     }


### PR DESCRIPTION
This PR is an attempt at making photo uploads parallel and adding a retry mechanism as well.
3 attempts are made for each image. Currently, if the registration on AirTable fails, it will also re-upload the entire image which is not ideal.

Relates to issues #35 and #37.