### PR TITLE
Various networking robustness measures

### DIFF
--- a/Tree Tracker/Constants.swift
+++ b/Tree Tracker/Constants.swift
@@ -13,4 +13,10 @@ enum Constants {
         static let cloudName = Secrets.cloudinaryCloudName
         static let uploadPresetName = Secrets.cloudinaryUploadPresetName
     }
+    enum Http {
+        static let requestWaitsForConnectivity = true
+        static let requestTimeoutSeconds: TimeInterval = 30
+        static let requestRetryDelaySeconds = 5
+        static let requestRetryLimit = 3
+    }
 }

--- a/Tree Tracker/Services/AlamofireApi.swift
+++ b/Tree Tracker/Services/AlamofireApi.swift
@@ -20,12 +20,20 @@ final class AlamofireApi: Api {
         }
     }
 
-    private let session = Session()
+    private let session: Session
     private let logger: Logging
     private var imageLoaders = [String: PHImageLoader]()
 
     init(logger: Logging = CurrentEnvironment.logger) {
         self.logger = logger
+        
+        let sessionConfig = URLSessionConfiguration.af.default
+        sessionConfig.timeoutIntervalForRequest = 30
+        sessionConfig.waitsForConnectivity = true
+        
+        self.session = Session(configuration: sessionConfig,
+                               interceptor: RetryingRequestInterceptor(retryDelaySecs: 5, maxRetries: 3))
+        
     }
  
     func treesPlanted(offset: String?, completion: @escaping (Result<Paginated<AirtableTree>, AFError>) -> Void) {

--- a/Tree Tracker/Services/AlamofireApi.swift
+++ b/Tree Tracker/Services/AlamofireApi.swift
@@ -28,11 +28,12 @@ final class AlamofireApi: Api {
         self.logger = logger
         
         let sessionConfig = URLSessionConfiguration.af.default
-        sessionConfig.timeoutIntervalForRequest = 30
-        sessionConfig.waitsForConnectivity = true
+        sessionConfig.timeoutIntervalForRequest = Constants.Http.requestTimeoutSeconds
+        sessionConfig.waitsForConnectivity = Constants.Http.requestWaitsForConnectivity
         
         self.session = Session(configuration: sessionConfig,
-                               interceptor: RetryingRequestInterceptor(retryDelaySecs: 5, maxRetries: 3))
+                               interceptor: RetryingRequestInterceptor(retryDelaySecs: Constants.Http.requestRetryDelaySeconds,
+                                                                       maxRetries: Constants.Http.requestRetryLimit))
         
     }
  

--- a/Tree Tracker/Services/RetryingRequestInterceptor.swift
+++ b/Tree Tracker/Services/RetryingRequestInterceptor.swift
@@ -1,0 +1,22 @@
+import Alamofire
+import Foundation
+
+class RetryingRequestInterceptor: RequestInterceptor {
+    var maxRetries: Int = 5
+    var retryDelay: TimeInterval = 10
+    
+    init(retryDelaySecs: Int, maxRetries retryLimit: Int) {
+        self.retryDelay = TimeInterval(retryDelaySecs)
+        self.maxRetries = retryLimit
+    }
+    
+    func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
+        let response = request.task?.response as? HTTPURLResponse
+        
+        if let statusCode = response?.statusCode, (500...599).contains(statusCode), request.retryCount < maxRetries {
+            completion(.retryWithDelay(retryDelay))
+        } else {
+            return completion(.doNotRetry)
+        }
+    }
+}


### PR DESCRIPTION
Networking enhancements in support of #35 through customisation of the AlamoFire session:
* default request timeout set to 30 seconds
* `waitsForConnectivity` set (will probably provide the greatest benefit)
* configurable retry interceptor added with max 3 retries with 5 second delay

Please note that this is my first foray into Swift and iOS development - so a strong peer review would be required. Changes have been tested on my iPhone 12 mini and appear to work as expected.