### PR TITLE
Don't trigger build on push

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,5 +1,11 @@
 name: build-release
-on: [pull_request]
+on: 
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 jobs:
   build:
     name: Build default scheme

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,5 +1,5 @@
 name: build-release
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   build:
     name: Build default scheme


### PR DESCRIPTION
We are triggering more builds than needed; remove push trigger for the build/release action except on branch `main`.