### PR TITLE
Version to 0.8.0

### DIFF
--- a/Tree Tracker/Info.plist
+++ b/Tree Tracker/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.1</string>
+	<string>0.8.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Unit Tests/Info.plist
+++ b/Unit Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.1</string>
+	<string>0.8.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
Previous PR #57 did not correctly increment the version number. Taking this opportunity to bump version to 0.8.0 to reflect the significant change to base iOS version which makes this release non backwards compatible.