### PR TITLE
Adds location accuracy aware camera overlay

### DIFF
--- a/Tree Tracker.xcodeproj/project.pbxproj
+++ b/Tree Tracker.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		9D01D562285CD2E50009F753 /* RollbarCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 9D01D561285CD2E50009F753 /* RollbarCommon */; };
 		9D01D564285CD2E50009F753 /* RollbarNotifier in Frameworks */ = {isa = PBXBuildFile; productRef = 9D01D563285CD2E50009F753 /* RollbarNotifier */; };
 		9D01D566285CD2E50009F753 /* RollbarSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 9D01D565285CD2E50009F753 /* RollbarSwift */; };
+		9D2B454F2944F54000B09C84 /* LocationWarningOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2B454E2944F54000B09C84 /* LocationWarningOverlayView.swift */; };
 		9D47D97F286F293000F7B92F /* ProtectEarthSupervisor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D47D97E286F293000F7B92F /* ProtectEarthSupervisor.swift */; };
 		9D47D982286F29E100F7B92F /* ProtectEarthCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D47D981286F29E100F7B92F /* ProtectEarthCodableTests.swift */; };
 		9D562D6528B81BDE00B66716 /* ProtectEarthUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D562D6428B81BDE00B66716 /* ProtectEarthUpload.swift */; };
@@ -235,6 +236,7 @@
 		85DC214525E0FCBF003F0721 /* GRDBImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GRDBImageCache.swift; sourceTree = "<group>"; };
 		85E0E05D25B33F8C009D8FC0 /* TappableButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TappableButton.swift; sourceTree = "<group>"; };
 		85E0E06125B35744009D8FC0 /* UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
+		9D2B454E2944F54000B09C84 /* LocationWarningOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationWarningOverlayView.swift; sourceTree = "<group>"; };
 		9D47D97E286F293000F7B92F /* ProtectEarthSupervisor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectEarthSupervisor.swift; sourceTree = "<group>"; };
 		9D47D981286F29E100F7B92F /* ProtectEarthCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectEarthCodableTests.swift; sourceTree = "<group>"; };
 		9D562D6428B81BDE00B66716 /* ProtectEarthUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectEarthUpload.swift; sourceTree = "<group>"; };
@@ -572,6 +574,7 @@
 				85B839B725B47C3F0008E167 /* TreeCollectionViewCell.swift */,
 				85CC02EB261B6EA90016E618 /* TextTableViewCell.swift */,
 				9DB29B572821D50000AAC73D /* SimpleTableViewCell.swift */,
+				9D2B454E2944F54000B09C84 /* LocationWarningOverlayView.swift */,
 			);
 			path = "UI Components";
 			sourceTree = "<group>";
@@ -827,6 +830,7 @@
 				85B839E725B862B80008E167 /* CollectionViewDataSource.swift in Sources */,
 				9D5F062D2874E35D00C8D4A6 /* ProtectEarthSiteService.swift in Sources */,
 				8534160025CF09CE006DDAC4 /* PHPhotoLibrary.swift in Sources */,
+				9D2B454F2944F54000B09C84 /* LocationWarningOverlayView.swift in Sources */,
 				853415FD25CF0957006DDAC4 /* UIEdgeInsets.swift in Sources */,
 				85B83A3025B9C5E90008E167 /* JSONEncoder.swift in Sources */,
 				9DA1FC34283452CC00AEC584 /* AppDelegate+Injection.swift in Sources */,

--- a/Tree Tracker/Extensions/UIImage.swift
+++ b/Tree Tracker/Extensions/UIImage.swift
@@ -24,4 +24,5 @@ extension UIImage {
     static var cameraIcon: UIImage { UIImage(systemName: "camera")! }
     static var map: UIImage { UIImage(systemName: "map")! }
     static var settingsIcon: UIImage { UIImage(systemName: "gearshape")! }
+    static var warningTriangle: UIImage { UIImage(systemName: "exclamationmark.triangle")! }
 }

--- a/Tree Tracker/Screens/Upload Session/UploadSessionViewController.swift
+++ b/Tree Tracker/Screens/Upload Session/UploadSessionViewController.swift
@@ -154,7 +154,12 @@ final class UploadSessionViewController: UIViewController, UIImagePickerControll
             let picker = RotatingUIImagePickerController()
             picker.modalPresentationStyle = .overCurrentContext
             picker.mediaTypes = ["public.image"]
-            picker.sourceType = .camera
+            if !UIImagePickerController.isSourceTypeAvailable(.camera) {
+                picker.sourceType = .photoLibrary
+            } else {
+                picker.sourceType = .camera
+                picker.cameraOverlayView = LocationWarningOverlayView(frame: (picker.cameraOverlayView?.frame)!)
+            }
             picker.delegate = self
             self?.present(picker, animated: true, completion: nil)
         }
@@ -180,7 +185,9 @@ final class UploadSessionViewController: UIViewController, UIImagePickerControll
             return
         }
 
-        picker.stopVideoCapture()
+        if picker.sourceType == .camera {
+            picker.stopVideoCapture()
+        }
         photoSessionCompletion?(.success(image))
     }
 }

--- a/Tree Tracker/UI Components/LocationWarningOverlayView.swift
+++ b/Tree Tracker/UI Components/LocationWarningOverlayView.swift
@@ -1,0 +1,88 @@
+import UIKit
+import CoreLocation
+
+class LocationWarningOverlayView: UIView, CLLocationManagerDelegate {
+
+    // MARK: - Properties
+     
+    private let warningIconImageView = UIImageView()
+    private let gpsAccuracyLabel = UILabel()
+    private let locationManager = CLLocationManager()
+
+    // MARK: - Initialization
+     
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        locationManager.delegate = self
+        locationManager.startUpdatingLocation()
+
+        self.isUserInteractionEnabled = false
+
+        // Set up the warning icon image view
+        warningIconImageView.image = .warningTriangle
+        warningIconImageView.contentMode = .scaleAspectFit
+        warningIconImageView.tintColor = .systemYellow
+        addSubview(warningIconImageView)
+
+        // Set up the GPS accuracy label
+        gpsAccuracyLabel.textColor = .systemYellow
+        gpsAccuracyLabel.font = UIFont.systemFont(ofSize: 14)
+        gpsAccuracyLabel.text = "Establishing GPS Accuracy..."
+        gpsAccuracyLabel.textAlignment = .center
+        addSubview(gpsAccuracyLabel)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK - CLLocationManagerDelegate
+    
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        updateGPSAccuracy(accuracy: locations[0].horizontalAccuracy)
+    }
+    
+    // MARK: - Layout
+     
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        let orientation = UIDevice.current.orientation
+
+        // Set the frame of the warning icon image view
+        warningIconImageView.frame = CGRect(x: 0, y: 0, width: 50, height: 50)
+
+        // Set the frame of the GPS accuracy label
+        gpsAccuracyLabel.sizeToFit()
+        gpsAccuracyLabel.frame = CGRect(x: 0,
+                                        y: warningIconImageView.frame.maxY + 30,
+                                        width: gpsAccuracyLabel.frame.width,
+                                        height:gpsAccuracyLabel.frame.height)
+
+        if orientation == .portrait || orientation == .portraitUpsideDown {
+            warningIconImageView.center = CGPoint(x: frame.midX, y: frame.midY - 50)
+            gpsAccuracyLabel.center = CGPoint(x: frame.midX, y: frame.midY)
+        } else {
+            warningIconImageView.center = CGPoint(x: frame.midY, y: frame.midX - 50)
+            gpsAccuracyLabel.center = CGPoint(x: frame.midY, y: frame.midX)
+        }
+    }
+
+    // MARK: - GPS Accuracy
+     
+    func updateGPSAccuracy(accuracy: CLLocationAccuracy) {
+        print(accuracy)
+        let accm = Int(round(accuracy))
+        if accm > 5 {
+            // Show the warning icon and set the text of the GPS accuracy label
+            warningIconImageView.isHidden = false
+            gpsAccuracyLabel.isHidden = false
+            gpsAccuracyLabel.text = "GPS Accuracy: \(accm) m"
+        } else {
+            // Hide the warning icon and clear the text of the GPS accuracy label
+            warningIconImageView.isHidden = true
+            gpsAccuracyLabel.isHidden = true
+        }
+    }
+}


### PR DESCRIPTION
Adds a camera overlay view which shows a warning message and current location accuracy to the nearest 1m. This warning currently appears when resolution is over 5m. The warning does not prevent an image being taken, nor does it appear on the taken photo.