### PR TITLE
Force stage build to run after prod

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -49,7 +49,7 @@ jobs:
     name: Build and publish - Stage
     if: ${{ github.ref_name == 'main' && github.event_name != 'pull_request' }}
     runs-on: macos-latest
-    needs: test
+    needs: build-publish-prod
     environment:
       name: Stage
     steps:


### PR DESCRIPTION
To avoid issues where App Store Connect will reject builds with lower version numbers than a previously published build, force stage (builds ending .1) to run after prod (builds ending effectively .0).